### PR TITLE
Added correct column count checking when compiling insert statements

### DIFF
--- a/src/SQL/ir.cpp
+++ b/src/SQL/ir.cpp
@@ -768,6 +768,16 @@ Optional<Slice<U32>> compile_graph_node(StmtGraph* g, U32 node_id, IrContext* ct
         OK_ASSERT(node->up.stmt->type == Stmt::INSERT);
 
         auto *insert_stmt = static_cast<InsertStmt*>(node->up.stmt);
+        // TODO(oleh): Check if the column names are also valid.
+        UZ mandatory_columns_count = table_schema.value->columns_names.count;
+        if (insert_stmt->columns.count != mandatory_columns_count) {
+            String error_message = String::format(ctx->allocator,
+                                                  "the table has %zu mandatory columns, tried to insert %zu instead",
+                                                  mandatory_columns_count,
+                                                  insert_stmt->columns.count);
+            ctx->error_on(insert_stmt->token, error_message);
+            return {};
+        }
 
         ctx->push_table(table_node_id.value);
         {

--- a/src/SQL/type_check.cpp
+++ b/src/SQL/type_check.cpp
@@ -146,7 +146,6 @@ static inline bool type_check_ir_instruction(U32 ip, CompiledQuery *ir_emitter, 
     case IRInstructionOperator_EmitQuery: {
         Tuple<String, U32> operands = operands_of_EmitQuery(ir_emitter, ip);
         U32 columns_to_emit_count = operands.op2;
-        printf("%zu %u\n", ctx->emitted_columns.count, columns_to_emit_count);
         OK_ASSERT(ctx->emitted_columns.count >= columns_to_emit_count);
 
         List<Optional<String>> column_names = List<Optional<String>>::alloc(ctx->allocator);

--- a/tests/SQL-ir-test.cpp
+++ b/tests/SQL-ir-test.cpp
@@ -172,7 +172,7 @@ TEST(ir, insert) {
         column1 int,
         column2 text
     );
-    INSERT INTO MyTable (column1) VALUES (1), (2), (3);)sql"_sv;
+    INSERT INTO MyTable (column1, column2) VALUES (1, "1"), (2, "2"), (3, "3");)sql"_sv;
     Parser parser{&arena, source};
 
     auto query = parser.query();


### PR DESCRIPTION
The semantic analysis stage now checks if the supplied column names count matches the table's column count