### PR TITLE
Removed the `DBTable::F_EPHEMERAL` flag by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ foreach(test_file ${test_files})
     ${test_file}
   )
 
+  target_compile_definitions(${test_exe_name} PRIVATE XMDB_TEST)
+
   target_link_libraries(
     ${test_exe_name}
     GTest::gtest_main
@@ -51,7 +53,7 @@ foreach(test_file ${test_files})
 
   target_link_libraries(
     ${test_exe_name}
-    LibCore
+    LibCore_test
     LibSQL::shared
   )
 
@@ -72,9 +74,11 @@ foreach(snap_file ${snap_files})
   add_executable(${snap_exe_name} ${snap_file})
   add_test(NAME ${snap_exe_name} COMMAND ${snap} "-f" "-d" ${snapdir} ${snap_exe_name})
 
+  target_compile_definitions(${snap_exe_name} PRIVATE XMDB_TEST)
+
   target_link_libraries(
     ${snap_exe_name}
-    LibCore
+    LibCore_test
     LibSQL::shared
   )
 endforeach()

--- a/src/Core/BTreeIndex.cpp
+++ b/src/Core/BTreeIndex.cpp
@@ -132,6 +132,7 @@ struct BTreeState {
             OK_VERIFY(read_count == buffer_count);
 
             state = allocator->alloc<BTreeState>();
+            state->state_file = state_file;
             state->flags = 0;
             state->allocator = allocator;
             state->header = (DiskHeader *) buffer;

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -24,3 +24,9 @@ add_library(LibCore
 
 set_property(TARGET LibCore PROPERTY POSITION_INDEPENDENT_CODE 1)
 target_link_libraries(LibCore PUBLIC libweb)
+
+add_library(LibCore_test STATIC $<TARGET_PROPERTY:LibCore,SOURCES>)
+set_property(TARGET LibCore_test PROPERTY POSITION_INDEPENDENT_CODE 1)
+target_compile_definitions(LibCore_test PRIVATE XMDB_TEST)
+target_include_directories(LibCore_test PUBLIC $<TARGET_PROPERTY:LibCore,INCLUDE_DIRECTORIES>)
+target_link_libraries(LibCore_test PUBLIC libweb)

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(LibCore
   state.cpp
   image.cpp
   StaticStorage.cpp
+  catalog.cpp
 )
 
 set_property(TARGET LibCore PROPERTY POSITION_INDEPENDENT_CODE 1)

--- a/src/Core/Core.cpp
+++ b/src/Core/Core.cpp
@@ -28,4 +28,35 @@ bool compile_and_execute_source(ok::ArenaAllocator *arena,
 
     return true;
 }
+
+void populate_ir_context_from_pool(SQL::IrContext *ctx,
+                                   DBPool *pool) {
+    ctx->database_schemas.count = 0;
+    ctx->error = {};
+
+    for (DBDescriptor *db = pool->db_descriptors; db != nullptr; db = db->next) {
+        SQL::DBSchema db_schema = SQL::DBSchema::alloc(ctx->allocator, db->name);
+
+        for (UZ table_idx = 0; table_idx < db->tables.count; ++table_idx) {
+            DBTable *table = db->tables[table_idx];
+            ok::String table_name = table->name().to_string(ctx->allocator);
+            SQL::TableSchema *table_schema = db_schema.alloc_table_schema(table_name, true);
+
+            ok::Slice<ok::StringView> column_names = table->columns_names();
+            ok::Slice<SQL::ColumnType> column_types = table->columns_types();
+
+            ok::List<SQL::ColumnType> &schema_column_types = table_schema->columns_types.get();
+
+            for (UZ col_idx = 0; col_idx < table->columns_count(); ++col_idx) {
+                ok::String column_name = column_names[col_idx].to_string(ctx->allocator);
+                SQL::ColumnType column_type = column_types[col_idx];
+
+                table_schema->columns_names.push(column_name);
+                schema_column_types.push(column_type);
+            }
+        }
+
+        ctx->database_schemas.push(db_schema);
+    }
+}
 } // namespace xmdb

--- a/src/Core/Core.hpp
+++ b/src/Core/Core.hpp
@@ -18,4 +18,13 @@ bool compile_and_execute_source(ok::ArenaAllocator *arena,
                                 StringView source,
                                 QueryResults *results,
                                 String *error);
+
+/**
+ * @brief Populates the provided IrContext from a DBPool, providing information
+   about existing databases, users and tables.
+ * @param ctx The IR context.
+ * @param pool The database pool.
+ */
+void populate_ir_context_from_pool(SQL::IrContext *ctx,
+                                   DBPool *pool);
 } // namespace xmdb

--- a/src/Core/DBConnection.cpp
+++ b/src/Core/DBConnection.cpp
@@ -246,6 +246,9 @@ static void execute_instruction(TypedCompiledQuery *query, UZ i, QueryExecutionC
         }
 
         OK_ASSERT(deleted);
+
+        ctx->sync_state();
+
         break;
     }
     case IRInstructionOperator_DropDatabase: {
@@ -277,6 +280,9 @@ static void execute_instruction(TypedCompiledQuery *query, UZ i, QueryExecutionC
         }
 
         OK_ASSERT(deleted);
+
+        ctx->sync_state();
+
         break;
     }
     case IRInstructionOperator_Arg: {
@@ -296,40 +302,6 @@ static void execute_instruction(TypedCompiledQuery *query, UZ i, QueryExecutionC
 
         break;
     }
-#if 0
-    case IRInstructionOperator_RGB: {
-        Triple<ok::String, S64, ok::StringView> operands = operands_of_RGB(&query->untyped, i);
-
-        U32 w = (U64)operands.op2 >> 32;
-        U32 h = (U64)operands.op2 & ~(U32)0;
-
-        ok::StringView input = operands.op3;
-
-        ok::Optional<ok::Slice<U8>> input_data_opt = from_hex_string(ctx->allocator, input);
-
-        if (!input_data_opt.has_value()) {
-            XMDB_FAIL(ctx,
-                      "Failed to parse the 'data' argument as a valid hex string");
-        }
-
-        ok::Slice<U8> input_data = input_data_opt.get();
-        UZ expected_data_count = w * h * format_pixel_size_in_bytes(PixelFormat::RGB);
-        if (input_data.count != expected_data_count) {
-            XMDB_FAIL_FMT(ctx,
-                          "Expected the 'data' argument to be of length %zu (width * height * pixel size), got %zu bytes instead",
-                          expected_data_count,
-                          input_data.count);
-        }
-
-        auto *value = new (ctx->allocator) ImageDataDBValue{w, h, input_data, PixelFormat::RGB};
-
-        ok::StringView var_name = operands.op1.view();
-
-        ctx->put_var(i, var_name, value);
-
-        break;
-    }
-#endif // 0
     }
 }
 
@@ -610,6 +582,8 @@ static void run_single_node(QueryExecutionContext *ctx, QueryGraph::Node *node) 
             break;
         }
         }
+
+        ctx->sync_state();
 
         break;
     }

--- a/src/Core/DBDescriptor.cpp
+++ b/src/Core/DBDescriptor.cpp
@@ -2,6 +2,7 @@
 #include "new.hpp"
 #include "Logger.hpp"
 #include "SDFile.hpp"
+#include "state.hpp"
 
 namespace xmdb {
 DBDescriptor *DBDescriptor::alloc(ok::Allocator *allocator, ok::StringView name) {
@@ -113,4 +114,113 @@ DBTable *DBDescriptor::create_new_table(ok::Allocator *allocator,
 
     return table;
 }
+
+Result<DBTable *, ok::String> DBDescriptor::load_existing_table(ok::Allocator *allocator,
+                                                                ok::StringView name,
+                                                                DBTable::Flags flags,
+                                                                UZ columns_count,
+                                                                ok::Slice<ok::StringView> column_names,
+                                                                ok::Slice<SQL::ColumnType> column_types) {
+    OK_ASSERT((flags & DBTable::F_PROXY) == 0);
+    OK_ASSERT((flags & DBTable::F_EPHEMERAL) == 0);
+
+    SHA256Digest table_name_digest = sha256_digest(name);
+    ok::Slice<U8> table_name_slice = table_name_digest.bytes.slice();
+    ok::String table_digest_hex = to_hex_string(ok::temp_allocator(), table_name_slice);
+    ok::String table_index_file_name = ok::String::format(allocator, "%s.xdb", table_digest_hex.cstr());
+    ok::String table_state_file_name = ok::String::format(allocator, "%s.sdb", table_digest_hex.cstr());
+
+    ok::File table_index_file{};
+
+    ok::Optional<ok::File::OpenError> open_err = ok::File::open(&table_index_file, table_index_file_name.view());
+    if (open_err) {
+        ok::String error_desc = ok::File::error_string(ok::temp_allocator(), open_err.get());
+        return ok::String::format(allocator,
+                                  "Failed to open table index file '%s': %s",
+                                  table_index_file_name.cstr(),
+                                  error_desc.cstr());
+    }
+
+    BTreeIndex table_index = BTreeIndex::create(allocator, table_index_file);
+
+    ok::File table_state_file{};
+
+    open_err = ok::File::open(&table_state_file, table_state_file_name.view());
+    if (open_err) {
+        ok::String error_desc = ok::File::error_string(ok::temp_allocator(), open_err.get());
+        return ok::String::format(allocator,
+                                  "Failed to open table state file '%s': %s",
+                                  table_state_file_name.cstr(),
+                                  error_desc.cstr());
+    }
+
+    Result<DBState, ok::String> db_state_load_result = db_state_load(allocator, table_state_file);
+
+    if (!db_state_load_result.ok()) {
+        return ok::String::format(allocator,
+                                  "Failed to load db state from a file: %s",
+                                  db_state_load_result.error().cstr());
+    }
+
+    DBState db_state = db_state_load_result.unwrap();
+
+    ok::List<ColumnAttribute> column_attributes = ok::List<ColumnAttribute>::alloc(allocator);
+
+    for (UZ col_idx = 0; col_idx < columns_count; ++col_idx) {
+        SQL::ColumnType column_type = column_types[col_idx];
+        ok::Optional<ColumnAttribute> attr_opt = get_attribute_for_column_type(column_type);
+
+        if (!attr_opt) continue;
+
+        ColumnAttribute attr = attr_opt.get();
+
+        if (attr.flags & ColumnAttribute::F_IMAGE) {
+            ok::StringView column_name = column_names[col_idx];
+
+            ok::String image_file_name = ok::String::format(ok::temp_allocator(), OK_SV_FMT "-" OK_SV_FMT ".idb", OK_SV_ARG(name), OK_SV_ARG(column_name));
+
+            ok::File image_file{};
+            open_err = ok::File::open(&image_file, image_file_name.view());
+            if (open_err) {
+                ok::String error_desc = ok::File::error_string(ok::temp_allocator(), open_err.get());
+                return ok::String::format(allocator,
+                                          "Failed to open an image column state file '%s': %s",
+                                          image_file_name.cstr(),
+                                          error_desc.cstr());
+            }
+
+            Result<ImageColumnState, ok::String> load_image_state_result = image_state_load(allocator,
+                                                                                            image_file);
+            if (!load_image_state_result.ok()) {
+                return ok::String::format(allocator,
+                                          "Failed to load an image column state from file '%s': %s",
+                                          image_file_name.cstr(),
+                                          load_image_state_result.error().cstr());
+            }
+
+            ImageColumnState &image_col_state = load_image_state_result.unwrap();
+            attr.u.image_state = image_col_state;
+        }
+
+        column_attributes.push(attr);
+    }
+
+    DBTable *table = new (allocator) DBTable{
+        allocator,
+        flags,
+        name,
+        columns_count,
+        column_names.items,
+        column_types.items,
+        column_attributes.items,
+    };
+
+    table->set_index(table_index);
+    table->set_state(db_state);
+
+    tables.push(table);
+
+    return table;
+}
+
 } // namespace xmdb

--- a/src/Core/DBDescriptor.hpp
+++ b/src/Core/DBDescriptor.hpp
@@ -45,7 +45,7 @@ struct DBDescriptor {
      * @param allocator The allocator to use for the table.
      * @param name The name of the table.
      * @param flags The table flags (e.g., storage type).
-     * @param columns_count The number of columns in the table.
+     * @param column_count The number of columns in the table.
      * @param column_names The names of the columns.
      * @param column_types The types of the columns.
      * @return A pointer to the newly created table.
@@ -53,16 +53,26 @@ struct DBDescriptor {
     DBTable *create_new_table(ok::Allocator *allocator,
                               ok::StringView name,
                               DBTable::Flags flags,
-                              UZ columns_count,
+                              UZ column_count,
                               ok::Slice<ok::StringView> column_names,
                               ok::Slice<SQL::ColumnType> column_types);
 
     /**
-     * @brief Loads an existing table by name.
-     * @param name The name of the table to load.
-     * @return An optional containing the table if found, or empty otherwise.
+     * @brief Loads an existing table from disk.
+     * @param allocator The allocator to use for the table.
+     * @param name The name of the table.
+     * @param flags The table flags (e.g., storage type).
+     * @param column_count The number of columns in the table.
+     * @param column_names The names of the columns.
+     * @param column_types The types of the columns.
+     * @return A result with an allocated table on success, an error string otherwise.
      */
-    ok::Optional<DBTable *> load_existing_table(ok::StringView name);
+    Result<DBTable *, ok::String> load_existing_table(ok::Allocator *allocator,
+                                                      ok::StringView name,
+                                                      DBTable::Flags flags,
+                                                      UZ column_count,
+                                                      ok::Slice<ok::StringView> column_names,
+                                                      ok::Slice<SQL::ColumnType> column_types);
 
     DBDescriptor *next;             ///< Pointer to the next database descriptor in a list.
     ok::StringView name;            ///< The name of the database.

--- a/src/Core/DBPool.cpp
+++ b/src/Core/DBPool.cpp
@@ -1,14 +1,49 @@
 #include "DBPool.hpp"
+#include "Logger.hpp"
+#include "catalog.hpp"
 
 using namespace ok::literals;
 
 namespace xmdb {
-DBPool::DBPool(ok::Allocator *allocator) : allocator{allocator}, execution_contexts{nullptr} {
-    const StringView default_db_name = "default"_sv;
-    DBDescriptor *db = create_db(default_db_name);
-    DBUser *admin = allocator->alloc<DBUser>();
-    *admin = DBUser::admin();
-    db->add_user(admin);
+constexpr ok::StringView DEFAULT_CATALOG_FILE_NAME = "xmdb.cat"_sv;
+
+DBPool::DBPool(ok::Allocator *allocator, Flags flags) : allocator{allocator},
+                                                        flags{flags},
+                                                        execution_contexts{nullptr} {
+    XMDB_FIXME("Replace this constructor by either a static method or a function, it can fail");
+
+#ifdef XMDB_TEST
+    this->flags |= F_EPHEMERAL;
+#endif // XMDB_TEST
+
+    catalog_file_name = DEFAULT_CATALOG_FILE_NAME;
+
+    if (!ephemeral() && ok::File::exists(catalog_file_name)) {
+        log::info("Found a catalog file in the current directory (" OK_SV_FMT "), loading it",
+                  OK_SV_ARG(catalog_file_name));
+
+        Result<UZ, ok::String> cat_load_result = catalog_load(allocator, this, catalog_file_name);
+        if (!cat_load_result.ok()) {
+            OK_PANIC_FMT("Failed to load the catalog: %s",
+                         cat_load_result.error().cstr());
+        }
+    } else {
+        const StringView default_db_name = "default"_sv;
+        DBDescriptor *db = DBDescriptor::alloc(allocator, default_db_name);
+        db->next = nullptr;
+        this->db_descriptors = db;
+
+        DBUser *admin = allocator->alloc<DBUser>();
+        *admin = DBUser::admin();
+        db->add_user(admin);
+
+        if (!ephemeral()) {
+            Result<UZ, ok::String> cat_save_result = catalog_save(allocator, this, catalog_file_name);
+            if (!cat_save_result.ok()) {
+                OK_PANIC_FMT("Failed to save a catalog to disk: %s", cat_save_result.error().cstr());
+            }
+        }
+    }
 }
 
 DBDescriptor *DBPool::get_db(StringView db_name) {
@@ -33,6 +68,7 @@ QueryExecutionContext *DBPool::rent_empty_execution_context(DBDescriptor *db, DB
         QueryExecutionContext *ctx = execution_contexts;
         ctx->static_storage = make_or_get_static_storage();
         ctx->query_graph.reset();
+        ctx->db_pool = this;
         ctx->current_db = db;
         ctx->user = user;
         ctx->vars.clear();
@@ -64,6 +100,7 @@ QueryExecutionContext *DBPool::rent_empty_execution_context(DBDescriptor *db, DB
     ctx->rows_to_insert = ok::List<ok::Pair<Slice<StringView>, Slice<DBValue *>>>::alloc(allocator);
     ctx->columns_to_update = ok::MultiList<StringView, DBValue *>::alloc(allocator);
     ctx->call_args = ok::List<DBValue *>::alloc(allocator);
+    ctx->db_pool = this;
     ctx->current_db = db;
     ctx->table_to_update = {};
     ctx->last_emitted_query = {};
@@ -74,5 +111,9 @@ QueryExecutionContext *DBPool::rent_empty_execution_context(DBDescriptor *db, DB
 void DBPool::return_execution_context(QueryExecutionContext *ctx) {
     ctx->next = execution_contexts;
     execution_contexts = ctx;
+}
+
+Result<UZ, ok::String> sync_db_pool(DBPool *pool) {
+    return catalog_save(pool->allocator, pool, pool->catalog_file_name);
 }
 } // namespace xmdb

--- a/src/Core/DBPool.hpp
+++ b/src/Core/DBPool.hpp
@@ -11,11 +11,17 @@ namespace xmdb {
  * @brief Manages a pool of databases and execution contexts.
  */
 struct DBPool {
+    using Flags = U16;
+    enum : Flags {
+        F_EPHEMERAL = 1 << 0, ///< No catalog data will be loaded or stored.
+    };
+
     /**
      * @brief Constructs a new DBPool.
      * @param allocator The allocator to use for pool resources.
+     * @param flags Flags for this pool.
      */
-    DBPool(ok::Allocator *allocator);
+    DBPool(ok::Allocator *allocator, Flags flags = 0);
 
     /**
      * @brief Retrieves a database descriptor by name.
@@ -45,8 +51,24 @@ struct DBPool {
      */
     void return_execution_context(QueryExecutionContext *context);
 
+    /**
+     * @brief Tries to sync this pool's catalog to disk.
+     * @return The number of bytes written on success, error string otherwise.
+     */
+    Result<UZ, ok::String> sync_to_disk();
+
+    /**
+     * @brief Returns whether this DBPool is ephemeral.
+     * @return true if the F_EPHEMERAL flag is set, false otherwise
+     */
+    bool ephemeral() const {
+        return (flags & F_EPHEMERAL) == 1;
+    }
+
     ok::Allocator *allocator;               ///< The allocator for the pool.
+    Flags flags;                            ///< Behavior flags.
     QueryExecutionContext *execution_contexts; ///< List of available execution contexts.
     DBDescriptor *db_descriptors;           ///< List of database descriptors.
+    ok::StringView catalog_file_name;        ///< File name for the pool's catalog.
 };
 } // namespace xmdb

--- a/src/Core/DBTable.cpp
+++ b/src/Core/DBTable.cpp
@@ -8,6 +8,19 @@
 using namespace ok::literals;
 
 namespace xmdb {
+ok::Optional<ColumnAttribute> get_attribute_for_column_type(SQL::ColumnType column_type) {
+    if (column_type == SQL::ColumnType::PNG) {
+        return ColumnAttribute{
+            .flags = ColumnAttribute::F_IMAGE,
+            .u = {
+                .image_state = {},
+            },
+        };
+    } else {
+        return {};
+    }
+}
+
 struct TypeLayout {
     static constexpr UZ MAX_ALIGNMENT = sizeof(UZ);
 
@@ -119,6 +132,61 @@ DBTable::DBTable(ok::Allocator *allocator,
 
         m_column_attributes[i] = attribute;
     }
+}
+
+DBTable::DBTable(ok::Allocator *allocator,
+                 DBTable::Flags flags,
+                 ok::StringView name,
+                 UZ columns_count,
+                 ok::StringView *columns_names,
+                 SQL::ColumnType *columns_types,
+                 ColumnAttribute *column_attributes) : m_name{name},
+                                                       m_flags{flags},
+                                                       m_columns_count{columns_count},
+                                                       m_columns_names{columns_names},
+                                                       m_columns_types{columns_types} {
+    ColumnLayout *columns_layout = compute_columns_layout(allocator, columns_count, columns_types);
+
+    UZ id_column_index = (UZ)-1;
+    for (UZ col_idx = 0; col_idx < columns_count; ++col_idx) {
+        if (columns_names[col_idx] == "id"_sv) {
+            id_column_index = col_idx;
+            break;
+        }
+    }
+
+    if (id_column_index == (UZ)-1) {
+        OK_VERIFY(columns_count > 0);
+        id_column_index = 0;
+    }
+
+    XMDB_FIXME("DBTable constructor searches for a column with name 'id' and sets it as a primary key column");
+
+    m_layout.primary_key_index = id_column_index;
+    m_layout.columns.items = columns_layout;
+    m_layout.columns.count = columns_count;
+
+    if (flags & F_PROXY) {
+        OK_ASSERT(flags & F_ANON);
+
+        m_proxy_columns_values = allocator->alloc<DBValue *>(m_columns_count);
+        for (UZ col_idx = 0; col_idx < m_columns_count; ++col_idx) {
+            m_proxy_columns_values[col_idx] = new (allocator) NoneDBValue{};
+        }
+    }
+
+    if (flags & F_EPHEMERAL) {
+        OK_ASSERT(flags & F_PERSIST);
+    }
+
+    for (UZ col_idx = 0; col_idx < m_columns_count; ++col_idx) {
+        SQL::Type ty = SQL::column_type_to_type(m_columns_types[col_idx]);
+        bool type_is_image = is_image(ty);
+        bool attr_is_image = column_attributes[col_idx].flags & ColumnAttribute::F_IMAGE;
+        OK_VERIFY(type_is_image == attr_is_image);
+    }
+
+    m_column_attributes = column_attributes;
 }
 
 struct StreamPair {

--- a/src/Core/DBTable.hpp
+++ b/src/Core/DBTable.hpp
@@ -26,6 +26,13 @@ struct ColumnAttribute {
 };
 
 /**
+ * @brief Gets an attribute for a column type, if any.
+ * @param column_type The column type.
+ * @return An Optional ColumnAttribute
+ */
+ok::Optional<ColumnAttribute> get_attribute_for_column_type(SQL::ColumnType column_type);
+
+/**
  * @brief Represents a database table, managing its metadata and data.
  */
 class DBTable {
@@ -56,6 +63,24 @@ public:
             UZ column_count,
             ok::StringView *column_names,
             SQL::ColumnType *column_types);
+
+    /**
+     * @brief Constructs a new DBTable.
+     * @param allocator The allocator to use.
+     * @param flags The table flags.
+     * @param name The name of the table.
+     * @param column_count The number of columns.
+     * @param column_names The names of the columns.
+     * @param column_types The types of the columns.
+     * @param column_attributes The attributes of the columns.
+     */
+    DBTable(ok::Allocator *allocator,
+            Flags flags,
+            ok::StringView name,
+            UZ column_count,
+            ok::StringView *column_names,
+            SQL::ColumnType *column_types,
+            ColumnAttribute *column_attributes);
 
     /**
      * @brief Gets the table flags.

--- a/src/Core/QueryExecutionContext.cpp
+++ b/src/Core/QueryExecutionContext.cpp
@@ -77,9 +77,15 @@ void QueryExecutionContext::create_table(StringView table_name, SQL::TableSchema
         }
     }
 
+    DBTable::Flags table_flags = DBTable::F_PERSIST;
+
+#ifdef XMDB_TEST
+    table_flags |= DBTable::F_EPHEMERAL;
+#endif // XMDB_TEST
+
     DBTable *new_table = current_db->create_new_table(allocator,
                                                       table_name,
-                                                      DBTable::F_EPHEMERAL | DBTable::F_PERSIST,
+                                                      table_flags,
                                                       column_types.count,
                                                       column_names,
                                                       column_types.slice());

--- a/src/Core/QueryExecutionContext.cpp
+++ b/src/Core/QueryExecutionContext.cpp
@@ -18,6 +18,17 @@ XMDB_ENUM_USER_PERMISSIONS
 
 #undef X
 
+Result<UZ, ok::String> sync_db_pool(DBPool *);
+
+void QueryExecutionContext::sync_state() {
+    auto result = sync_db_pool(db_pool);
+    if (!result.ok()) {
+        XMDB_FAIL_FMT(this,
+                      "Failed to write database state to disk: %s",
+                      result.error().cstr());
+    }
+}
+
 DBValue *QueryExecutionContext::fetch_var(U32 ip) {
     CHECK_READ(this);
     Optional<DBValue *> value = vars.get(ip);
@@ -65,6 +76,8 @@ void QueryExecutionContext::create_table(StringView table_name, SQL::TableSchema
         OK_TODO();
     }
 
+    XMDB_FIXME("Add 'CREATE TABLE' node to the query graph");
+
     UZ columns_count = table_schema->columns_names.count;
     List<SQL::ColumnType> column_types = table_schema->columns_types.value;
     ok::StringView *column_names_ptr = allocator->alloc<ok::StringView>(columns_count);
@@ -95,6 +108,8 @@ void QueryExecutionContext::create_table(StringView table_name, SQL::TableSchema
                       "Failed to create table '" OK_SV_FMT "', see the log for details",
                       OK_SV_ARG(table_name));
     }
+
+    sync_state();
 }
 
 void QueryExecutionContext::emit_column(DBTable *table, DBValue *column_value, StringView column_name) {
@@ -165,9 +180,6 @@ void QueryExecutionContext::commit_insert(DBTable *table) {
                        rows_to_insert.count);
 
     rows_to_insert.count = 0;
-
-#if 0
-#endif // 0
 }
 
 void QueryExecutionContext::update_column(DBTable *table, StringView column_name, DBValue *column_value) {
@@ -225,6 +237,8 @@ void QueryExecutionContext::create_user(StringView name) {
     DBUser *user = allocator->alloc<DBUser>();
     *user = {name, ""_sv, PERM_READ | PERM_WRITE};
     current_db->add_user(user);
+
+    sync_state();
 }
 
 void QueryExecutionContext::alter_user_property(StringView user_name, StringView property_name, DBValue *value) {

--- a/src/Core/QueryExecutionContext.hpp
+++ b/src/Core/QueryExecutionContext.hpp
@@ -28,6 +28,8 @@
     } while (false)
 
 namespace xmdb {
+struct DBPool;
+
 /**
  * @brief Context for executing a database query, managing variables, tables, and operations.
  * Note that the execution context does not actually perform any work (despite it's name) besides setting up all
@@ -179,6 +181,13 @@ struct QueryExecutionContext {
      */
     DBValue *call(StringView fn_name, U64 args_count);
 
+    /**
+     * @brief Syncs changed state (DBPool) to disk.
+     * @warning If the call to DBPool::sync_to_disk fails, this method
+     * will use 'longjmp' to transfer control to a safe point.
+     */
+    void sync_state();
+
     QueryExecutionContext *next;             ///< Pointer to the next context in a pool.
     StaticStorage *static_storage;           ///< Pointer to global static storage.
     QueryGraph query_graph;                  ///< The graph of operations to perform.
@@ -192,6 +201,7 @@ struct QueryExecutionContext {
     ok::MultiList<StringView, DBValue *, DBTable *> emitted_columns; ///< Columns emitted for the result.
     ok::MultiList<StringView, DBValue *> columns_to_update; ///< Columns pending update.
     Optional<QueryGraph::AtomicNode *> alter_user_atomic_node; ///< Atomic node for user alterations.
+    DBPool *db_pool;                         ///< The database pool in use.
     DBDescriptor *current_db;                ///< The database being queried.
     Optional<DBTable *> table_to_insert;     ///< Target table for insertion.
     Optional<DBTable *> table_to_update;     ///< Target table for update.

--- a/src/Core/catalog.cpp
+++ b/src/Core/catalog.cpp
@@ -5,19 +5,19 @@
 #include "Logger.hpp"
 
 namespace xmdb {
-struct CatalogDBEntry {
+struct [[gnu::packed]] CatalogDBEntry {
     FixedString name;
     U64 user_count;
     U64 table_count;
 };
 
-struct CatalogUserEntry {
+struct [[gnu::packed]] CatalogUserEntry {
     FixedString name;
-    SHA256Digest sha256_password_digest;
+    U8 sha256_password_digest[SHA256Digest::SIZE];
     U8 perm;
 };
 
-struct CatalogTableEntry {
+struct [[gnu::packed]] CatalogTableEntry {
     FixedString name;
     DBTable::Flags flags;
     U64 column_count;
@@ -76,9 +76,13 @@ Result<UZ, ok::String> catalog_save(ok::Allocator *allocator,
         for (DBUser *user = db->users; user != nullptr; user = user->next) {
             CatalogUserEntry user_entry = {
                 .name = create_fixed_string(user->name),
-                .sha256_password_digest = user->sha256_password_digest,
+                .sha256_password_digest = {},
                 .perm = user->perm,
             };
+
+            memcpy(&user_entry.sha256_password_digest,
+                   user->sha256_password_digest.bytes.items,
+                   sizeof(user_entry.sha256_password_digest));
 
             write(&file, &user_entry);
         }
@@ -160,7 +164,10 @@ Result<UZ, ok::String> catalog_load(ok::Allocator *allocator, DBPool *pool, ok::
             user->next = nullptr;
             user->name = user_entry.name.view().to_string(allocator).view();
             user->perm = user_entry.perm;
-            user->sha256_password_digest = user_entry.sha256_password_digest;
+
+            memcpy(user->sha256_password_digest.bytes.items,
+                   user_entry.sha256_password_digest,
+                   sizeof(user_entry.sha256_password_digest));
 
             db->add_user(user);
         }

--- a/src/Core/catalog.cpp
+++ b/src/Core/catalog.cpp
@@ -1,0 +1,205 @@
+#include "catalog.hpp"
+#include "DBPool.hpp"
+#include "DBDescriptor.hpp"
+#include "FixedString.hpp"
+#include "Logger.hpp"
+
+namespace xmdb {
+struct CatalogDBEntry {
+    FixedString name;
+    U64 user_count;
+    U64 table_count;
+};
+
+struct CatalogUserEntry {
+    FixedString name;
+    SHA256Digest sha256_password_digest;
+    U8 perm;
+};
+
+struct CatalogTableEntry {
+    FixedString name;
+    DBTable::Flags flags;
+    U64 column_count;
+};
+
+template <typename T>
+static void write(ok::File *file, const T *value) {
+    UZ n_written = 0;
+    ok::Optional<ok::File::WriteError> write_err = file->write(reinterpret_cast<const U8 *>(value),
+                                                               sizeof(*value),
+                                                               &n_written);
+    OK_VERIFY(!write_err);
+    OK_VERIFY(n_written == sizeof(*value));
+}
+
+Result<UZ, ok::String> catalog_save(ok::Allocator *allocator,
+                                    DBPool *pool,
+                                    ok::StringView filename) {
+    ok::File file{};
+    ok::Optional<ok::File::OpenError> open_err = ok::File::open(&file, filename);
+    if (open_err) {
+        ok::String error_desc = ok::File::error_string(ok::temp_allocator(), open_err.get());
+        return ok::String::format(allocator, "Failed to open catalog file for writing: %s", error_desc.cstr());
+        return false;
+    }
+
+    U64 db_count = 0;
+    for (DBDescriptor *db = pool->db_descriptors; db != nullptr; db = db->next) {
+        ++db_count;
+    }
+
+    CatalogHeader header = {
+        .magic = CATALOG_HEADER_MAGIC,
+        .version = CATALOG_VERSION,
+        .db_count = db_count,
+    };
+
+    file.seek_start();
+
+    write(&file, &header);
+
+    for (DBDescriptor *db = pool->db_descriptors; db != nullptr; db = db->next) {
+        U64 user_count = 0;
+        for (DBUser *user = db->users; user != nullptr; user = user->next) {
+            ++user_count;
+        }
+
+        CatalogDBEntry entry = {
+            .name = create_fixed_string(db->name),
+            .user_count = user_count,
+            .table_count = db->tables.count,
+        };
+
+        write(&file, &entry);
+
+        for (DBUser *user = db->users; user != nullptr; user = user->next) {
+            CatalogUserEntry user_entry = {
+                .name = create_fixed_string(user->name),
+                .sha256_password_digest = user->sha256_password_digest,
+                .perm = user->perm,
+            };
+
+            write(&file, &user_entry);
+        }
+
+        for (UZ table_idx = 0; table_idx < db->tables.count; ++table_idx) {
+            DBTable *table = db->tables[table_idx];
+
+            CatalogTableEntry table_entry = {
+                .name = create_fixed_string(table->name()),
+                .flags = table->flags(),
+                .column_count = table->columns_count(),
+            };
+
+            write(&file, &table_entry);
+
+            ok::Slice<ok::StringView> col_names = table->columns_names();
+            ok::Slice<SQL::ColumnType> col_types = table->columns_types();
+
+            for (UZ col_idx = 0; col_idx < table->columns_count(); ++col_idx) {
+                ok::StringView col_name = col_names[col_idx];
+                FixedString raw_col_name = create_fixed_string(col_name);
+                write(&file, &raw_col_name);
+
+                SQL::ColumnType col_type = col_types[col_idx];
+                U8 raw_col_type = static_cast<U8>(col_type);
+                write(&file, &raw_col_type);
+            }
+        }
+    }
+
+    file.close();
+
+    return file.offset;
+}
+
+template <typename T>
+static void read(ok::File *file, T *out) {
+    UZ n_read;
+    ok::Optional<ok::File::ReadError> err = file->read(reinterpret_cast<U8 *>(out), sizeof(*out), &n_read);
+    OK_VERIFY(!err);
+    OK_VERIFY(n_read == sizeof(*out));
+}
+
+Result<UZ, ok::String> catalog_load(ok::Allocator *allocator, DBPool *pool, ok::StringView filename) {
+    ok::File file{};
+    ok::Optional<ok::File::OpenError> open_err = ok::File::open(&file, filename);
+    if (open_err) {
+        return false;
+    }
+
+    file.seek_start();
+
+    CatalogHeader header{};
+    read(&file, &header);
+
+    if (header.magic != CATALOG_HEADER_MAGIC) {
+        file.close();
+        return ok::String::alloc(allocator, "Invalid catalog file magic number");
+    }
+
+    if (header.version != CATALOG_VERSION) {
+        file.close();
+        return ok::String::format(allocator, "Unsupported catalog version %lu", header.version);
+    }
+
+    pool->db_descriptors = nullptr;
+
+    for (U64 db_idx = 0; db_idx < header.db_count; ++db_idx) {
+        CatalogDBEntry db_entry{};
+        read(&file, &db_entry);
+
+        DBDescriptor *db = pool->create_db(db_entry.name.view().to_string(allocator).view());
+
+        for (U64 user_idx = 0; user_idx < db_entry.user_count; ++user_idx) {
+            CatalogUserEntry user_entry{};
+            read(&file, &user_entry);
+
+            DBUser *user = allocator->alloc<DBUser>();
+            user->next = nullptr;
+            user->name = user_entry.name.view().to_string(allocator).view();
+            user->perm = user_entry.perm;
+            user->sha256_password_digest = user_entry.sha256_password_digest;
+
+            db->add_user(user);
+        }
+
+        for (U64 table_idx = 0; table_idx < db_entry.table_count; ++table_idx) {
+            CatalogTableEntry table_entry{};
+            read(&file, &table_entry);
+
+            ok::Slice<ok::StringView> column_names = allocator->alloc_slice<ok::StringView>(table_entry.column_count);
+            ok::Slice<SQL::ColumnType> column_types = allocator->alloc_slice<SQL::ColumnType>(table_entry.column_count);
+
+            for (U64 col_idx = 0; col_idx < table_entry.column_count; ++col_idx) {
+                FixedString col_name_fs{};
+                read(&file, &col_name_fs);
+
+                U8 col_type_raw = 0;
+                read(&file, &col_type_raw);
+
+                column_names[col_idx] = col_name_fs.view();
+                column_types[col_idx] = static_cast<SQL::ColumnType>(col_type_raw);
+            }
+
+            ok::StringView table_name = table_entry.name.view().to_string(allocator).view();
+
+            Result<DBTable *, ok::String> load_table_result = db->load_existing_table(allocator,
+                                                                                      table_name,
+                                                                                      table_entry.flags,
+                                                                                      (UZ) table_entry.column_count,
+                                                                                      column_names,
+                                                                                      column_types);
+
+            if (!load_table_result.ok()) {
+                return load_table_result.error();
+            }
+        }
+    }
+
+    file.close();
+
+    return file.offset;
+}
+} // namespace xmdb

--- a/src/Core/catalog.hpp
+++ b/src/Core/catalog.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "ok.hpp"
+#include "state.hpp"
+
+namespace xmdb {
+struct DBPool;
+
+constexpr U64 CATALOG_HEADER_MAGIC = gen_magic("cxmdb"_sv);
+constexpr U64 CATALOG_VERSION = 1;
+
+struct CatalogHeader {
+    U64 magic;
+    U64 version;
+    U64 db_count;
+};
+
+Result<UZ, ok::String> catalog_save(ok::Allocator *allocator, DBPool *pool, ok::StringView filename);
+Result<UZ, ok::String> catalog_load(ok::Allocator *allocator, DBPool *pool, ok::StringView filename);
+} // namespace xmdb

--- a/src/Core/ok.hpp
+++ b/src/Core/ok.hpp
@@ -263,6 +263,9 @@ constexpr T min(T x, Rest... xs) {
     return x < xs_min ? x : xs_min;
 }
 
+template <typename T>
+struct Slice;
+
 struct Allocator {
     // required methods
     virtual void* raw_alloc(UZ size) = 0;
@@ -302,6 +305,9 @@ struct Allocator {
         result[len] = '\0';
         return result;
     }
+
+    template <typename T>
+    Slice<T> alloc_slice(UZ);
 };
 
 Allocator *temp_allocator();
@@ -381,9 +387,6 @@ struct ArenaAllocator : public Allocator {
 };
 
 // templates
-template <typename T>
-struct Slice;
-
 template <typename Self, typename T>
 struct ArrayBase {
     Slice<T> slice(UZ start, UZ end);
@@ -566,6 +569,12 @@ struct Slice : public ArrayBase<Slice<T>, T> {
     T* items;
     UZ count;
 };
+
+template <typename T>
+Slice<T> Allocator::alloc_slice(UZ count) {
+    T* ptr = alloc<T>(count);
+    return Slice<T>{ptr, count};
+}
 
 template <typename T>
 struct MultiListBase {
@@ -1638,6 +1647,9 @@ struct File {
     static Optional<OpenError> open(File* out, const char* path);
     static Optional<OpenError> open(File* out, StringView path);
 
+    static bool exists(const char* path);
+    static bool exists(StringView path);
+
 #if OK_UNIX
     static File from_fd(int fd, const char *path) {
         return File{
@@ -1663,7 +1675,7 @@ struct File {
     Optional<ReadError> read(U8* buf, UZ count, UZ* n_read);
     Optional<ReadError> read_full(Allocator* a, List<U8>* out);
 
-    Optional<WriteError> write(U8 *data, UZ count, UZ *n_written);
+    Optional<WriteError> write(const U8 *data, UZ count, UZ *n_written);
 
     inline Optional<WriteError> write(Slice<U8> data) {
         return write(data.items, data.count, nullptr);
@@ -1993,7 +2005,7 @@ String StringView::to_string(Allocator* a) const {
 // FILESYSTEM API IMPLEMENTATION
 Optional<File::OpenError> File::open(File* out, const char* path) {
 #if OK_UNIX
-    int fd = ::open(path, O_RDWR | O_CREAT);
+    int fd = ::open(path, O_RDWR | O_CREAT, 0666);
     int error = errno;
 
     if (fd < 0) {
@@ -2055,6 +2067,24 @@ Optional<File::OpenError> File::open(File* out, StringView path) {
     memcpy(path_cstr, path.data, path.count);
     path_cstr[path.count] = '\0';
     return File::open(out, path_cstr);
+}
+
+bool File::exists(const char* path) {
+#if OK_UNIX
+    return ::access(path, F_OK) == 0;
+#elif OK_WINDOWS
+    DWORD attrs = GetFileAttributesA(path);
+    return attrs != INVALID_FILE_ATTRIBUTES;
+#else
+    OK_TODO();
+#endif
+}
+
+bool File::exists(StringView path) {
+    char* path_cstr = temp_allocator()->alloc<char>(path.count + 1);
+    memcpy(path_cstr, path.data, path.count);
+    path_cstr[path.count] = '\0';
+    return File::exists(path_cstr);
 }
 
 #if OK_UNIX
@@ -2238,7 +2268,7 @@ Optional<File::CloseError> File::close() const {
 #endif // Platform check.
 }
 
-Optional<File::WriteError> File::write(U8* data, UZ count, UZ *n_written) {
+Optional<File::WriteError> File::write(const U8* data, UZ count, UZ *n_written) {
 #if OK_UNIX
     OK_VERIFY(data != nullptr);
 
@@ -2249,7 +2279,6 @@ Optional<File::WriteError> File::write(U8* data, UZ count, UZ *n_written) {
             *n_written = (UZ) ret;
         }
 
-        this->seek_to(this->offset);
         return {};
     }
 

--- a/src/Core/state.cpp
+++ b/src/Core/state.cpp
@@ -1,5 +1,6 @@
 #include "state.hpp"
 #include "Logger.hpp"
+#include "Result.hpp"
 
 namespace xmdb {
 bool db_state_create(ok::File file, DBState *out_state) {
@@ -47,6 +48,34 @@ bool db_state_reset(DBState *state) {
     return db_state_sync(state);
 }
 
+Result<DBState, ok::String> db_state_load(ok::Allocator *allocator, ok::File file) {
+    DBStateHeader header{};
+
+    file.seek_start();
+
+    UZ n_read = 0;
+    ok::Optional<ok::File::ReadError> read_err = file.read(reinterpret_cast<U8 *>(&header), sizeof(header), &n_read);
+    if (read_err) {
+        ok::String error_desc = ok::File::error_string(allocator, read_err.get());
+        return ok::String::format(allocator, "Failed to read state file header: %s", error_desc.cstr());
+    }
+
+    if (n_read != sizeof(header)) {
+        return ok::String::alloc(allocator, "State file is too small to contain a valid header");
+    }
+
+    if (header.magic != DB_STATE_HEADER_MAGIC) {
+        return ok::String::alloc(allocator, "Invalid state file magic number");
+    }
+
+    DBState state = {
+        .header = header,
+        .file = file,
+    };
+
+    return state;
+}
+
 bool image_state_create(ok::File file, ImageColumnState *out_state) {
     ImageColumnStateHeader header = {
         .magic = COLUMN_STATE_HEADER_MAGIC,
@@ -69,6 +98,34 @@ bool image_state_create(ok::File file, ImageColumnState *out_state) {
     out_state->file = file;
 
     return true;
+}
+
+Result<ImageColumnState, ok::String> image_state_load(ok::Allocator *allocator, ok::File file) {
+    ImageColumnStateHeader header{};
+
+    file.seek_start();
+
+    UZ n_read = 0;
+    ok::Optional<ok::File::ReadError> read_err = file.read(reinterpret_cast<U8 *>(&header), sizeof(header), &n_read);
+    if (read_err) {
+        ok::String error_desc = ok::File::error_string(allocator, read_err.get());
+        return ok::String::format(allocator, "Failed to read image state file header: %s", error_desc.cstr());
+    }
+
+    if (n_read != sizeof(header)) {
+        return ok::String::alloc(allocator, "Image state file is too small to contain a valid header");
+    }
+
+    if (header.magic != COLUMN_STATE_HEADER_MAGIC) {
+        return ok::String::alloc(allocator, "Invalid image state file magic number");
+    }
+
+    ImageColumnState state = {
+        .header = header,
+        .file = file,
+    };
+
+    return state;
 }
 
 bool image_state_sync(ImageColumnState *state) {

--- a/src/Core/state.hpp
+++ b/src/Core/state.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ok.hpp"
+#include "Result.hpp"
 
 namespace xmdb {
 using namespace ok::literals;
@@ -44,18 +45,26 @@ struct DBState {
 bool db_state_create(ok::File file, DBState *out);
 
 /**
+ * @brief Tries to load a DBState from an open file.
+ * @param allocator The allocator to use for error strings.
+ * @param file The file to use.
+ * @return A loaded DBState on success, an error string otherwise.
+ */
+Result<DBState, ok::String> db_state_load(ok::Allocator *allocator, ok::File file);
+
+/**
  * @brief Synchronizes the table state to disk.
  * @param state Pointer to the state to sync.
  * @return true if successful, false otherwise.
  */
-bool db_state_sync  (DBState *state);
+bool db_state_sync(DBState *state);
 
 /**
  * @brief Resets the table state.
  * @param state Pointer to the state to reset.
  * @return true if successful, false otherwise.
  */
-bool db_state_reset (DBState *state);
+bool db_state_reset(DBState *state);
 
 constexpr U64 COLUMN_STATE_HEADER_MAGIC = gen_magic("ixmdb"_sv);
 
@@ -86,9 +95,17 @@ struct ImageColumnState {
 bool image_state_create(ok::File file, ImageColumnState *out);
 
 /**
+ * @brief Loads an existing image column state from an open file.
+ * @param allocator The allocator to use for error strings.
+ * @param file The file to use.
+ * @return Loaded ImageColumnState on success, an error string otherwise.
+ */
+Result<ImageColumnState, ok::String> image_state_load(ok::Allocator *allocator, ok::File file);
+
+/**
  * @brief Synchronizes the image column state to disk.
  * @param state Pointer to the state to sync.
  * @return true if successful, false otherwise.
  */
-bool image_state_sync  (ImageColumnState *state);
+bool image_state_sync(ImageColumnState *state);
 } // namespace xmdb

--- a/src/SQL/ir.cpp
+++ b/src/SQL/ir.cpp
@@ -789,14 +789,12 @@ Optional<Slice<U32>> compile_graph_node(StmtGraph *g, U32 node_id, IrContext *ct
                 U32 edge_id = node->edges[i];
 
                 StmtGraphNode *expr_node = &g->nodes[edge_id];
-                Optional<Slice<U32>> expr_node_ids = compile_graph_node(g, edge_id, ctx);
-                TRY(expr_node_ids);
+                Optional<Slice<U32>> expr_node_ids_opt = compile_graph_node(g, edge_id, ctx);
+                TRY(expr_node_ids_opt);
 
-                columns_count += expr_node_ids.value.count;
+                Slice<U32> expr_node_ids = expr_node_ids_opt.get();
 
-                // NOTE(oleh): If we outputted more than 1 value, it means that we already have called
-                // the emit column procedure.
-                if (expr_node_ids.value.count > 1) continue;
+                columns_count += expr_node_ids.count;
 
                 StringView column_name = ""_sv;
 
@@ -805,8 +803,10 @@ Optional<Slice<U32>> compile_graph_node(StmtGraph *g, U32 node_id, IrContext *ct
                     column_name = ident->value.view();
                 }
 
-                U32 id = expr_node_ids.value[0];
-                emit_EmitColumn(&ctx->ir_emitter, expr_node->up.expr->token, table_node_id.value, id, column_name);
+                for (UZ expr_idx = 0; expr_idx < expr_node_ids.count; ++expr_idx) {
+                    U32 id = expr_node_ids[expr_idx];
+                    emit_EmitColumn(&ctx->ir_emitter, expr_node->up.expr->token, table_node_id.value, id, column_name);
+                }
             }
         }
         ctx->pop_namespace();

--- a/src/Server/connection.cpp
+++ b/src/Server/connection.cpp
@@ -4,7 +4,6 @@ namespace xmdb::server {
 static ConnectionId last_connection_id = 0;
 
 static ok::ArenaAllocator shared_arena{};
-xmdb::DBPool shared_db_pool{&shared_arena};
 static ok::Table<ConnectionId, ConnectionData> db_connections_table = ok::Table<ConnectionId, ConnectionData>::alloc(&shared_arena);
 
 using ConnectionList = ok::LinkedList<xmdb::DBConnection>;
@@ -14,11 +13,24 @@ Optional<ConnectionData> get_connection_data(ConnectionId id) {
     return db_connections_table.get(id);
 }
 
+static xmdb::DBPool *shared_db_pool;
+
+void init_connection_state() {
+    shared_db_pool = new (&shared_arena) DBPool{&shared_arena};
+}
+
+
+xmdb::DBPool *get_shared_db_pool() {
+    return shared_db_pool;
+}
+
 ConnectionId gen_connection(xmdb::DBDescriptor *db, xmdb::DBUser *user) {
+    DBPool *pool = get_shared_db_pool();
+
     xmdb::DBConnection *connection = nullptr;
 
     if (connection_free_list.head == nullptr) {
-        connection_free_list.prepend(xmdb::DBConnection{&shared_db_pool, db, user});
+        connection_free_list.prepend(xmdb::DBConnection{pool, db, user});
         connection = &connection_free_list.head->value;
     } else {
         ConnectionList::Node *conn_node = connection_free_list.pop_front();

--- a/src/Server/connection.hpp
+++ b/src/Server/connection.hpp
@@ -5,13 +5,15 @@
 namespace xmdb::server {
 using ConnectionId = U64;
 
-extern xmdb::DBPool shared_db_pool;
-
 struct ConnectionData {
     xmdb::DBConnection *connection;
     ok::ArenaAllocator temp_arena;
     xmdb::DBUser *user;
 };
+
+void init_connection_state();
+
+xmdb::DBPool *get_shared_db_pool();
 
 ConnectionId gen_connection(xmdb::DBDescriptor *db, xmdb::DBUser *user);
 Optional<ConnectionData> get_connection_data(ConnectionId);

--- a/src/Server/http.cpp
+++ b/src/Server/http.cpp
@@ -138,6 +138,10 @@ DECLARE_HANDLER(run_query_handler) {
     xmdb::QueryResults query_results{};
     ok::String error{};
 
+    DBPool *shared_db_pool = get_shared_db_pool();
+
+    populate_ir_context_from_pool(&connection_data.connection->ir_ctx, shared_db_pool);
+
     bool ok = xmdb::compile_and_execute_source(&connection_data.temp_arena, connection_data.connection, source_sv,
                                                &query_results, &error);
 

--- a/src/Server/http.cpp
+++ b/src/Server/http.cpp
@@ -56,7 +56,9 @@ DECLARE_HANDLER(connect_handler) {
     ok::StringView db_name_sv{(const char *) db_name.Items, db_name.Count};
     xmdb::DBDescriptor *requested_db = nullptr;
 
-    for (xmdb::DBDescriptor *db = shared_db_pool.db_descriptors; db != nullptr; db = db->next) {
+    DBPool *shared_db_pool = get_shared_db_pool();
+
+    for (xmdb::DBDescriptor *db = shared_db_pool->db_descriptors; db != nullptr; db = db->next) {
         if (db->name == db_name_sv) {
             requested_db = db;
             break;

--- a/src/Server/http.cpp
+++ b/src/Server/http.cpp
@@ -5,6 +5,7 @@
 #include <Core/ok.hpp>
 
 #include <http.h>
+#include <log.h>
 
 #include "connection.hpp"
 #include "http.hpp"
@@ -377,6 +378,8 @@ DECLARE_HANDLER(get_db_objects_handler) {
 }
 
 void run_http_server(U16 port) {
+    WebLogSetDestination(stdout);
+
     web_http_server server{};
     web_http_server_config config{
         // TODO(oleh): Make this configurable for user.

--- a/src/Server/main.cpp
+++ b/src/Server/main.cpp
@@ -6,6 +6,7 @@
 
 #include <SQL/global_state.hpp>
 
+#include "connection.hpp"
 #include "http.hpp"
 #include "Config.hpp"
 
@@ -15,6 +16,8 @@ int main(int argc, char **argv) {
     Config config = Config::parse(argc, argv);
 
     xmdb::SQL::init_global_state();
+
+    init_connection_state();
 
     switch (config.protocol) {
     case Protocol::HTTP: {


### PR DESCRIPTION
* Added a database 'catalog' for this, which stores info about databases and their tables (one file for now)
* All the data is persistent by default now, unless you are running tests
* Also fixed an IR codegen bug (still doing some stuff wrong, but we don't crash the server anymore)